### PR TITLE
Fix some bugs

### DIFF
--- a/src/components/core/fillinthegaps/core.js
+++ b/src/components/core/fillinthegaps/core.js
@@ -27,6 +27,7 @@ function FillGapBox(objectdata){
 util.inherits(FillGapBox,CBobject);
 
 FillGapBox.prototype.cloneTrigger = function cloneTrigger() {
+  FillGapBox.super_.prototype.cloneTrigger.call(this);
   this.fgpidentifier = "pem_" + this.uniqueid ; 
 };
 

--- a/src/components/core/interactiveoneoption/core.js
+++ b/src/components/core/interactiveoneoption/core.js
@@ -143,6 +143,7 @@ PEMBox.prototype.triggerHTMLView = function triggerHTMLView() {
 };
 
 PEMBox.prototype.cloneTrigger = function cloneTrigger() {
+  PEMBox.super_.prototype.cloneTrigger.call(this);
   this.pemidentifier = "pem_" + this.uniqueid ; 
 };
 

--- a/src/js/lib/core/backend/core.js
+++ b/src/js/lib/core/backend/core.js
@@ -383,10 +383,17 @@ Backend.prototype.deleteSection = function(cbsectionid) {
    */
   var CBStorage = application.storagemanager.getInstance();
   var pool = [cbsectionid];
+  var objects=[];
   while(tempcbsectionid = pool.shift()){
     section = CBStorage.getSectionById(tempcbsectionid);
     pool = pool.concat(section.sections);
+    objects=section.content;
+    objects.forEach(function(elements){
+           CBStorage.deleteCBObjectById(elements);
+    });
+
     CBStorage.deleteSectionById(tempcbsectionid);
+    
   }
 
 };

--- a/src/js/lib/core/exportPdf.js
+++ b/src/js/lib/core/exportPdf.js
@@ -108,7 +108,10 @@ ExportPdf.prototype.renderPdf = function renderPdf(parametrosPdf, origen) {
             var destextrafiles = path.dirname(parametrosPdf.path) + "/pdfextrafiles";
             if(fs.existsSync(extrafilesorig)){
             	fsextra.move(extrafilesorig,destextrafiles,function(err){console.log(err);$("#exportpdfwizard").dialog("destroy");});
+            }else{
+                $("#exportpdfwizard").dialog("destroy");
             }
+
             //that.borrarHtml(origen);
         } else {
             $("#exportpdfwizard").find('.waitingOK').css("display", "none");

--- a/src/js/lib/gui/ui/proview/core.js
+++ b/src/js/lib/gui/ui/proview/core.js
@@ -238,6 +238,7 @@ ProView.prototype.dialogUpdateSectionName = function dialogUpdateSectionName(cbs
 
 ProView.prototype.deleteSection = function deleteSection(cbsectionid) {
 	$('[data-cbsectionid="'+cbsectionid+'"]').remove();
+  $(Cloudbook.UI.targetcontent).html("");
 };
 
 


### PR DESCRIPTION
Fix this bugs:
-Clone Fillinthegaps  and interactiveoneoption components
-When clone a section with Fillinthegaps  or interactiveoneoption components and then remove one of this component in the cloned section the component is delete in the origin section too
-When a section is delete the content doesn't delete of the project data info
-The export pdf gui doesn't close when the process end if the project don't have "extrafiles"
